### PR TITLE
IdRef.parse() return null when "path" parameter blank

### DIFF
--- a/yawp-core/src/main/java/io/yawp/repository/IdRef.java
+++ b/yawp-core/src/main/java/io/yawp/repository/IdRef.java
@@ -7,6 +7,8 @@ import io.yawp.repository.query.QueryBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class IdRef<T> implements Comparable<IdRef<T>> {
 
     private Repository r;
@@ -120,6 +122,10 @@ public class IdRef<T> implements Comparable<IdRef<T>> {
 
     @SuppressWarnings("unchecked")
     public static <TT> IdRef<TT> parse(Repository r, HttpVerb verb, String path) {
+		if (StringUtils.isBlank(path)) {
+			return null;
+		}
+		
         String[] parts = path.substring(1).split("/");
 
         if (parts.length < 2) {

--- a/yawp-core/src/test/java/io/yawp/repository/IdRefAsStringTest.java
+++ b/yawp-core/src/test/java/io/yawp/repository/IdRefAsStringTest.java
@@ -102,6 +102,18 @@ public class IdRefAsStringTest extends EndpointTestCase {
         IdRef<Parent> parentId = IdRef.parse(yawp, GET, "/parents/a");
         assertIdRef(parentId, Parent.class, "a");
     }
+    
+    @Test
+    public void testParseEmptyBlank() {
+        IdRef<Parent> parentId = IdRef.parse(yawp, GET, "");
+        assertEquals(null, parentId);
+        
+        parentId = IdRef.parse(yawp, GET, null);
+        assertEquals(null, parentId);
+        
+        parentId = IdRef.parse(yawp, GET, " ");
+        assertEquals(null, parentId);
+    }
 
     @Test
     public void testParseChildId() {

--- a/yawp-core/src/test/java/io/yawp/repository/IdRefAsStringTest.java
+++ b/yawp-core/src/test/java/io/yawp/repository/IdRefAsStringTest.java
@@ -104,7 +104,7 @@ public class IdRefAsStringTest extends EndpointTestCase {
     }
     
     @Test
-    public void testParseEmptyBlank() {
+    public void testParseBlankPath() {
         IdRef<Parent> parentId = IdRef.parse(yawp, GET, "");
         assertEquals(null, parentId);
         


### PR DESCRIPTION
When passing an blank string it throws exception, better threat as an null return.

IdRef.parse(yawp, GET, "")

[INFO] java.lang.StringIndexOutOfBoundsException: String index out of range: -1
[INFO] 	at java.lang.String.substring(String.java:1875)
[INFO] 	at io.yawp.repository.IdRef.parse(IdRef.java:136)