### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/IdRefToKey.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/IdRefToKey.java
@@ -11,6 +11,8 @@ import com.google.appengine.api.datastore.KeyFactory;
 
 public class IdRefToKey {
 
+    private IdRefToKey() {}
+
     public static Key toKey(Repository r, IdRef<?> id) {
         return convertWithinRightNamespace(r, id.getClazz(), id);
     }

--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/CacheHelper.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/CacheHelper.java
@@ -14,6 +14,8 @@ public class CacheHelper {
 
     public static final long POW_2_15 = (long) Math.pow(2, 15);
 
+    private CacheHelper() {}
+
     public static String createIndexCacheKey(String sinkUri) {
         return String.format("%s-%s", INDEX_PREFIX, sinkUri);
     }

--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/utils/QueueHelper.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/utils/QueueHelper.java
@@ -7,6 +7,9 @@ import com.google.appengine.api.taskqueue.QueueFactory;
 import io.yawp.repository.pipes.Pipe;
 
 public class QueueHelper {
+
+    private QueueHelper() {}
+
     public static Queue getPipeQueue(Pipe pipe) {
         if (pipe.getQueueName() == null) {
             return getDefaultQueue();

--- a/yawp-core/src/main/java/io/yawp/commons/utils/DateUtils.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/DateUtils.java
@@ -10,6 +10,8 @@ public class DateUtils {
 
     public static final String DATE_FORMAT = "yyyy/MM/dd";
 
+    private DateUtils() {}
+
     public static String fromTimestamp(Date timestamp) {
         return format(timestamp, TIMESTAMP_FORMAT);
     }

--- a/yawp-core/src/main/java/io/yawp/commons/utils/Environment.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/Environment.java
@@ -17,6 +17,8 @@ public class Environment {
 
     private static final String YAWP_APP_DIR = "yawp.dir";
 
+    private Environment() {}
+
     public static boolean isProduction() {
         if (get() != null) {
             return getOrDefault().equals("production");

--- a/yawp-core/src/main/java/io/yawp/commons/utils/JsonUtils.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/JsonUtils.java
@@ -20,6 +20,8 @@ import java.util.Map.Entry;
 
 public class JsonUtils {
 
+    private JsonUtils() {}
+
     private static Gson buildGson(Repository r) {
         GsonBuilder builder = new GsonBuilder();
         builder.setDateFormat(DateUtils.TIMESTAMP_FORMAT);

--- a/yawp-core/src/main/java/io/yawp/commons/utils/NameGenerator.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/NameGenerator.java
@@ -10,6 +10,8 @@ import java.util.UUID;
 public class NameGenerator {
     private static Base64 BASE64 = new Base64(true);
 
+    private NameGenerator() {}
+
     public static String generateFromUUID() {
         UUID uuid = UUID.randomUUID();
         byte[] byteArray = toByteArray(uuid);

--- a/yawp-core/src/main/java/io/yawp/commons/utils/ReflectionUtils.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/ReflectionUtils.java
@@ -7,6 +7,8 @@ import java.util.*;
 
 public final class ReflectionUtils {
 
+    private ReflectionUtils() {}
+
     public static List<Field> getImmediateFields(Class<?> clazz) {
         List<Field> finalFields = new ArrayList<>();
         for (Field field : clazz.getDeclaredFields()) {

--- a/yawp-core/src/main/java/io/yawp/commons/utils/ServiceLookup.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/ServiceLookup.java
@@ -6,6 +6,8 @@ public class ServiceLookup {
 
     public static final String SERVICES_PATH = "META-INF/services/";
 
+    private ServiceLookup() {}
+
     public static <T> T lookup(Class<T> clazz) {
         ResourceFinder finder = new ResourceFinder(SERVICES_PATH);
         return lookup(finder, clazz);

--- a/yawp-core/src/main/java/io/yawp/driver/api/DriverFactory.java
+++ b/yawp-core/src/main/java/io/yawp/driver/api/DriverFactory.java
@@ -5,6 +5,8 @@ import io.yawp.repository.Repository;
 
 public class DriverFactory {
 
+    private DriverFactory() {}
+
     public static Driver getDriver(Repository r) {
         Driver driver = lookup();
         driver.init(r);

--- a/yawp-core/src/main/java/io/yawp/driver/api/testing/TestHelperFactory.java
+++ b/yawp-core/src/main/java/io/yawp/driver/api/testing/TestHelperFactory.java
@@ -5,6 +5,8 @@ import io.yawp.repository.Repository;
 
 public class TestHelperFactory {
 
+    private TestHelperFactory() {}
+
     public static TestHelper getTestHelper(Repository r) {
         TestHelper helper = lookup(TestHelper.class);
 

--- a/yawp-core/src/main/java/io/yawp/repository/actions/RepositoryActions.java
+++ b/yawp-core/src/main/java/io/yawp/repository/actions/RepositoryActions.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 public class RepositoryActions {
 
+    private RepositoryActions() {}
+
     public static Object execute(Repository r, ActionMethod actionMethod, IdRef<?> id, String json, Map<String, String> params) {
         boolean rollback = false;
         atomicBegin(r, actionMethod);

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/RepositoryHooks.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/RepositoryHooks.java
@@ -10,6 +10,8 @@ import java.lang.reflect.Method;
 
 public class RepositoryHooks {
 
+    private RepositoryHooks() {}
+
     public static void beforeShield(Repository r, Object object) {
         invokeHooks(r, object.getClass(), object, "beforeShield");
     }

--- a/yawp-core/src/main/java/io/yawp/repository/pipes/RepositoryPipes.java
+++ b/yawp-core/src/main/java/io/yawp/repository/pipes/RepositoryPipes.java
@@ -7,6 +7,8 @@ import io.yawp.repository.query.NoResultException;
 
 public class RepositoryPipes {
 
+    private RepositoryPipes() {}
+
     public static void flux(Repository r, Object source) {
         Class<?> endpointClazz = source.getClass();
 

--- a/yawp-core/src/main/java/io/yawp/repository/query/condition/Condition.java
+++ b/yawp-core/src/main/java/io/yawp/repository/query/condition/Condition.java
@@ -2,6 +2,8 @@ package io.yawp.repository.query.condition;
 
 public abstract class Condition {
 
+    private Condition() {}
+
     public static BaseCondition c(String field, String operator, Object comparison) {
         return c(field, WhereOperator.toOperator(operator), comparison);
     }

--- a/yawp-core/src/main/java/io/yawp/repository/transformers/RepositoryTransformers.java
+++ b/yawp-core/src/main/java/io/yawp/repository/transformers/RepositoryTransformers.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public class RepositoryTransformers {
 
+    private RepositoryTransformers() {}
+
     @SuppressWarnings("unchecked")
     public static <F, T> T execute(Repository r, F object, String name) {
         TransformerRunner transformerRunner = new TransformerRunner<F>(r, object.getClass(), name);

--- a/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/appengine/ClassLoaderPatch.java
+++ b/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/appengine/ClassLoaderPatch.java
@@ -12,6 +12,8 @@ import java.util.List;
 public class ClassLoaderPatch {
     private static final Class<?>[] parameters = new Class[]{URL.class};
 
+    private ClassLoaderPatch() {}
+
     public static void addFiles(List<String> paths) {
         for (String path : paths) {
             addFile(path);

--- a/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/SdkResolver.java
+++ b/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/SdkResolver.java
@@ -39,6 +39,8 @@ public class SdkResolver {
     private static final String SDK_ARTIFACT_ID = "appengine-java-sdk";
     private static final String SDK_EXTENSION = "zip";
 
+    private SdkResolver() {}
+
     @SuppressWarnings("unchecked")
     public static File getSdk(MavenProject project, RepositorySystem repoSystem, RepositorySystemSession repoSession,
                               List<RemoteRepository>... repos) throws MojoExecutionException {

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/IdRefToKey.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/IdRefToKey.java
@@ -10,6 +10,8 @@ import io.yawp.repository.Repository;
 
 public class IdRefToKey {
 
+    private IdRefToKey() {}
+
     public static Key toKey(Repository r, IdRef<?> id) {
         return convertWithinRightNamespace(r, id.getClazz(), id);
     }

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/KeyFactory.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/KeyFactory.java
@@ -4,6 +4,8 @@ import io.yawp.repository.Namespace;
 
 public class KeyFactory {
 
+    private KeyFactory() {}
+
     private static Key createKey(Key parent, String kind, String name, Long id) {
         String ns = NamespaceManager.get();
         if (Namespace.GLOBAL.equals(ns)) {

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/NamespaceManager.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/NamespaceManager.java
@@ -6,6 +6,8 @@ public class NamespaceManager {
 
     private static ThreadLocal<String> namespace = new ThreadLocal<String>();
 
+    private NamespaceManager() {}
+
     public static String get() {
         String ns = namespace.get();
         return ns == null ? Namespace.GLOBAL : ns;

--- a/yawp-testing/yawp-testing-appengine/src/main/java/io/yawp/testing/appengine/AsyncHelper.java
+++ b/yawp-testing/yawp-testing-appengine/src/main/java/io/yawp/testing/appengine/AsyncHelper.java
@@ -11,6 +11,8 @@ public class AsyncHelper {
 
     private static CountDownLatch latch = null;
 
+    private AsyncHelper() {}
+
     public synchronized static void awaitAsync(long timeout, TimeUnit unit) {
         if (latch != null) {
             throw new IllegalStateException("more than one wait is not allowed");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 660 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava