### PR TITLE
squid:S1165 - Exception classes should be immutable

### DIFF
--- a/yawp-core/src/main/java/io/yawp/commons/http/HttpException.java
+++ b/yawp-core/src/main/java/io/yawp/commons/http/HttpException.java
@@ -6,9 +6,9 @@ public class HttpException extends RuntimeException {
 
     private static final long serialVersionUID = -1369195874459839005L;
 
-    private int httpStatus;
+    private final int httpStatus;
 
-    private String text;
+    private final String text;
 
     public HttpException(int httpStatus, String text) {
         this.httpStatus = httpStatus;

--- a/yawp-core/src/main/java/io/yawp/repository/EndpointNotFoundException.java
+++ b/yawp-core/src/main/java/io/yawp/repository/EndpointNotFoundException.java
@@ -4,7 +4,7 @@ public class EndpointNotFoundException extends RuntimeException {
 
     private static final long serialVersionUID = 6669941619903531041L;
 
-    private String endpointPath;
+    private final String endpointPath;
 
     public EndpointNotFoundException(String endpointPath) {
         this.endpointPath = endpointPath;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1165 - Exception classes should be immutable.
This pull request removes technical debt of 60 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1165
Please let me know if you have any questions.
George Kankava