### PR TITLE
squid:S1905 - Redundant casts should not be used

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineQueryDriver.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineQueryDriver.java
@@ -394,7 +394,7 @@ public class AppengineQueryDriver implements QueryDriver {
     }
 
     private <T> Object getActualListFieldValue(String fieldName, Class<T> clazz, Collection<?> value) {
-        Collection<?> objects = (Collection<?>) value;
+        Collection<?> objects = value;
         List<Object> values = new ArrayList<>();
         for (Object obj : objects) {
             values.add(getActualFieldValue(fieldName, clazz, obj));

--- a/yawp-core/src/main/java/io/yawp/commons/utils/ResourceFinder.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/ResourceFinder.java
@@ -314,7 +314,7 @@ public class ResourceFinder {
      */
     public Class findClass(String uri) throws IOException, ClassNotFoundException {
         String className = findString(uri);
-        return (Class) classLoader.loadClass(className);
+        return classLoader.loadClass(className);
     }
 
     /**

--- a/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/SdkResolver.java
+++ b/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/SdkResolver.java
@@ -44,7 +44,7 @@ public class SdkResolver {
     @SuppressWarnings("unchecked")
     public static File getSdk(MavenProject project, RepositorySystem repoSystem, RepositorySystemSession repoSession,
                               List<RemoteRepository>... repos) throws MojoExecutionException {
-        Artifact artifact = (Artifact) find(project.getPluginArtifacts(), new Predicate<Artifact>() {
+        Artifact artifact = find(project.getPluginArtifacts(), new Predicate<Artifact>() {
             @Override
             public boolean apply(Artifact artifact1) {
                 return artifact1.getArtifactId().equals("appengine-maven-plugin");

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/Query.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/Query.java
@@ -394,7 +394,7 @@ public class Query {
     }
 
     private <T> Object getActualListFieldValue(String fieldName, Class<T> clazz, Collection<?> value) {
-        Collection<?> objects = (Collection<?>) value;
+        Collection<?> objects = value;
         List<Object> values = new ArrayList<>();
         for (Object obj : objects) {
             values.add(getActualFieldValue(fieldName, clazz, obj));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1905 - Redundant casts should not be used.
This pull request removes 20 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
Please let me know if you have any questions.
George Kankava