### PR TITLE
squid:S2142 - "InterruptedException" should not be ignored

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/JoinTask.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/JoinTask.java
@@ -213,6 +213,7 @@ public class JoinTask implements DeferredTask {
             try {
                 Thread.sleep(sleep);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
         }

--- a/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/DevServer.java
+++ b/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/DevServer.java
@@ -66,6 +66,7 @@ public class DevServer {
             monitor.start();
             monitor.join();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/DevServerWaitMojo.java
+++ b/yawp-maven-plugin/yawp-maven-plugin/src/main/java/io/yawp/plugin/mojos/devserver/DevServerWaitMojo.java
@@ -43,6 +43,7 @@ public class DevServerWaitMojo extends DevserverAbstractMojo {
         try {
             Thread.sleep(SLEEP_MILLIS);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/yawp-testing/yawp-testing-appengine/src/main/java/io/yawp/testing/appengine/AsyncHelper.java
+++ b/yawp-testing/yawp-testing-appengine/src/main/java/io/yawp/testing/appengine/AsyncHelper.java
@@ -22,6 +22,7 @@ public class AsyncHelper {
         try {
             latch.await(timeout, unit);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2142 - "InterruptedException" should not be ignored.
This pull request removes technical debt of 60 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2142
Please let me know if you have any questions.
George Kankava