### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineQueryDriver.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineQueryDriver.java
@@ -26,6 +26,9 @@ import java.util.*;
 
 public class AppengineQueryDriver implements QueryDriver {
 
+    // Filter for query
+    private static final String NORMALIZED_FIELD_PREFIX = "__";
+
     private Repository r;
 
     public AppengineQueryDriver(Repository r) {
@@ -276,10 +279,6 @@ public class AppengineQueryDriver implements QueryDriver {
 
         field.set(object, ids);
     }
-
-    // Filter for query
-
-    private static final String NORMALIZED_FIELD_PREFIX = "__";
 
     private Filter createFilter(QueryBuilder<?> builder, BaseCondition condition) throws FalsePredicateException {
         if (condition instanceof SimpleCondition) {

--- a/yawp-core/src/main/java/io/yawp/commons/utils/kind/KindResolver.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/kind/KindResolver.java
@@ -2,11 +2,6 @@ package io.yawp.commons.utils.kind;
 
 public abstract class KindResolver {
 
-    public abstract String getKind(Class<?> clazz);
-
-    @Deprecated
-    public abstract String getPath(String kind);
-
     private static final String KINDRESOLVER_SETTING_KEY = "yawp.kindresolver";
 
     private static KindResolver kindResolver;
@@ -14,6 +9,11 @@ public abstract class KindResolver {
     static {
         loadKindResolver();
     }
+
+    public abstract String getKind(Class<?> clazz);
+
+    @Deprecated
+    public abstract String getPath(String kind);
 
     private static void loadKindResolver() {
         String kindResolverClazzName = System.getProperty(KINDRESOLVER_SETTING_KEY);

--- a/yawp-core/src/main/java/io/yawp/repository/Repository.java
+++ b/yawp-core/src/main/java/io/yawp/repository/Repository.java
@@ -26,20 +26,20 @@ public class Repository implements RepositoryApi {
 
     private TransactionDriver tx;
 
-    public static Repository r() {
-        return new Repository();
-    }
-
-    public static Repository r(String ns) {
-        return new Repository(ns);
-    }
-
     private Repository() {
         this.namespace = new Namespace(driver().namespace());
     }
 
     private Repository(String ns) {
         this.namespace = new Namespace(ns, driver().namespace());
+    }
+
+    public static Repository r() {
+        return new Repository();
+    }
+
+    public static Repository r(String ns) {
+        return new Repository(ns);
     }
 
     @Override

--- a/yawp-core/src/main/java/io/yawp/repository/query/QueryBuilder.java
+++ b/yawp-core/src/main/java/io/yawp/repository/query/QueryBuilder.java
@@ -32,14 +32,14 @@ public class QueryBuilder<T> {
 
     private String cursor;
 
-    public static <T> QueryBuilder<T> q(Class<T> clazz, Repository r) {
-        return new QueryBuilder<T>(clazz, r);
-    }
-
     private QueryBuilder(Class<T> clazz, Repository r) {
         this.clazz = clazz;
         this.r = r;
         this.model = new ObjectModel(clazz);
+    }
+
+    public static <T> QueryBuilder<T> q(Class<T> clazz, Repository r) {
+        return new QueryBuilder<T>(clazz, r);
     }
 
     public <N> QueryTransformer<T, N> transform(String transformName) {

--- a/yawp-core/src/main/java/io/yawp/repository/query/QueryOptions.java
+++ b/yawp-core/src/main/java/io/yawp/repository/query/QueryOptions.java
@@ -27,10 +27,6 @@ public class QueryOptions {
 
     public String cursor;
 
-    public static QueryOptions parse(String json) {
-        return new QueryOptions(json);
-    }
-
     public QueryOptions(String json) {
         JsonObject jsonObject = (JsonObject) new JsonParser().parse(json);
 
@@ -40,6 +36,10 @@ public class QueryOptions {
         this.limit = parseLimit(jsonObject.get("limit"));
         this.returnCursor = parseReturnCursor(jsonObject.get("cursor"));
         this.cursor = parseCursor(jsonObject.get("cursor"));
+    }
+
+    public static QueryOptions parse(String json) {
+        return new QueryOptions(json);
     }
 
     private String parseCursor(JsonElement jsonElement) {

--- a/yawp-core/src/main/java/io/yawp/servlet/EndpointServlet.java
+++ b/yawp-core/src/main/java/io/yawp/servlet/EndpointServlet.java
@@ -26,6 +26,10 @@ public class EndpointServlet extends HttpServlet {
     public EndpointServlet() {
     }
 
+    protected EndpointServlet(String packagePrefix) {
+        initYawp(packagePrefix);
+    }
+
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
@@ -59,10 +63,6 @@ public class EndpointServlet extends HttpServlet {
 
     protected void setWithHooks(boolean enableHooks) {
         this.enableHooks = enableHooks;
-    }
-
-    protected EndpointServlet(String packagePrefix) {
-        initYawp(packagePrefix);
     }
 
     /**

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/Datastore.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/datastore/Datastore.java
@@ -19,14 +19,14 @@ public class Datastore {
 
     private static final String SQL_DELETE = "delete from :kind where key @> :key";
 
-    public static Datastore create(ConnectionManager connectionManager) {
-        return new Datastore(connectionManager);
-    }
-
     private ConnectionManager connectionManager;
 
     private Datastore(ConnectionManager connectionManager) {
         this.connectionManager = connectionManager;
+    }
+
+    public static Datastore create(ConnectionManager connectionManager) {
+        return new Datastore(connectionManager);
     }
 
     public Key put(Entity entity) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava