### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anything

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineHelpersDriver.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/AppengineHelpersDriver.java
@@ -8,7 +8,12 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class AppengineHelpersDriver implements HelpersDriver {
+
+    private final static Logger logger = Logger.getLogger(AppengineHelpersDriver.class.getName());
 
     @Override
     public void deleteAll() {
@@ -26,7 +31,7 @@ public class AppengineHelpersDriver implements HelpersDriver {
 
     @Override
     public void sync() {
-        System.out.println("appengine helper");
+        logger.log(Level.INFO, "appengine helper");
     }
 
 }

--- a/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/ShutdownMonitor.java
+++ b/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/ShutdownMonitor.java
@@ -6,8 +6,12 @@ import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ShutdownMonitor extends Thread {
+
+    private final static Logger logger = Logger.getLogger(ShutdownMonitor.class.getName());
 
     public static final String DEFAULT_PORT = "8359";
 
@@ -45,8 +49,7 @@ public class ShutdownMonitor extends Thread {
             }
 
             socket.close();
-            // TODO: using real logging
-            System.out.println("Stopping devserver...");
+            logger.log(Level.INFO, "Stopping devserver...");
             shutdown();
 
         } catch (Exception e) {

--- a/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/WebAppContextHelper.java
+++ b/yawp-maven-plugin/yawp-devserver-runtime/src/main/java/io/yawp/plugin/devserver/WebAppContextHelper.java
@@ -10,8 +10,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class WebAppContextHelper {
+
+    private final static Logger logger = Logger.getLogger(WebAppContextHelper.class.getName());
 
     protected MojoWrapper mojo;
 
@@ -62,8 +66,7 @@ public class WebAppContextHelper {
     }
 
     protected void configureHotDeploy() {
-        // TODO: using real logging
-        System.out.println("HotDeploy scanner: " + mojo.getHotDeployDir());
+        logger.log(Level.INFO, "HotDeploy scanner: " + mojo.getHotDeployDir());
         Scanner scanner = new Scanner();
         scanner.setScanInterval(mojo.getFullScanSeconds());
         scanner.setScanDirs(Arrays.asList(new File(mojo.getHotDeployDir())));
@@ -79,8 +82,7 @@ public class WebAppContextHelper {
                 if (!webapp.isStarted()) {
                     return;
                 }
-                // TODO: using real logging
-                System.out.println(filename + " updated, reloading the webapp!");
+                logger.log(Level.INFO, filename + " updated, reloading the webapp!");
                 restart(webapp);
             }
 

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/sql/SqlRunner.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/sql/SqlRunner.java
@@ -6,12 +6,16 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.postgresql.util.PGobject;
 
 public class SqlRunner {
+
+    private final static Logger logger = Logger.getLogger(SqlRunner.class.getName());
 
     @SuppressWarnings("serial")
     private class NotImplementedException extends RuntimeException {
@@ -89,7 +93,7 @@ public class SqlRunner {
             }
 
         } catch (SQLException e) {
-            System.out.println("problem with sql: " + sql);
+            logger.log(Level.INFO, "problem with sql: " + sql);
             throw new RuntimeException(e);
         } finally {
             try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S106 - Standard outputs should not be used directly to log anything.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
George Kankava