### PR TITLE
Hook Overhaul

### DIFF
--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/FutureKeyToIdRef.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/FutureKeyToIdRef.java
@@ -8,7 +8,7 @@ import io.yawp.repository.models.ObjectModel;
 
 import java.util.concurrent.Future;
 
-public class FutureKeyToIdRef extends FutureWrapper<Key, IdRef<?>> {
+public class FutureKeyToIdRef<T> extends FutureWrapper<Key, IdRef<T>> {
 
     private Repository r;
     private ObjectModel model;
@@ -24,9 +24,10 @@ public class FutureKeyToIdRef extends FutureWrapper<Key, IdRef<?>> {
         return t;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected IdRef<?> wrap(Key key) throws Exception {
-        return IdRefToKey.toIdRef(r, key, model);
+    protected IdRef<T> wrap(Key key) {
+        return (IdRef<T>) IdRefToKey.toIdRef(r, key, model);
     }
 
 }

--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/WorksExecutor.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/flow/WorksExecutor.java
@@ -47,7 +47,7 @@ public class WorksExecutor {
             executeWorks();
             commitIfChanged();
         } finally {
-            if (r.isTransationInProgress()) {
+            if (r.isTransactionInProgress()) {
                 r.rollback();
             }
         }
@@ -83,8 +83,8 @@ public class WorksExecutor {
 
         for (IdRef<?> sinkId : sinksToSave) {
             logSave(sinkId);
-            // TODO: support pipes at async repoistory operations
-            r.saveWithHooks(sinkCache.get(sinkId));
+            // TODO: support pipes at async repository operations
+            r.save(sinkCache.get(sinkId));
         }
 
         // TODO: destroy empty sinks?

--- a/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/reload/FlushSourceJob.java
+++ b/yawp-appengine/src/main/java/io/yawp/driver/appengine/pipes/reload/FlushSourceJob.java
@@ -41,7 +41,7 @@ public class FlushSourceJob extends Job2<Void, Class<? extends Pipe>, String> {
             r.driver().pipes().flux(pipe, source);
             r.commit();
         } finally {
-            if (r.isTransationInProgress()) {
+            if (r.isTransactionInProgress()) {
                 r.rollback();
             }
         }

--- a/yawp-core/src/main/java/io/yawp/commons/utils/ResourceFinder.java
+++ b/yawp-core/src/main/java/io/yawp/commons/utils/ResourceFinder.java
@@ -20,21 +20,8 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.JarURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Vector;
+import java.net.*;
+import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -49,12 +36,16 @@ public class ResourceFinder {
     private final ClassLoader classLoader;
     private final List<String> resourcesNotLoaded = new ArrayList<>();
 
+    private static URL[] nullArray() {
+        return null;
+    }
+
     public ResourceFinder(URL... urls) {
         this(null, Thread.currentThread().getContextClassLoader(), urls);
     }
 
     public ResourceFinder(String path) {
-        this(path, Thread.currentThread().getContextClassLoader(), null);
+        this(path, Thread.currentThread().getContextClassLoader(), nullArray());
     }
 
     public ResourceFinder(String path, URL... urls) {
@@ -62,7 +53,7 @@ public class ResourceFinder {
     }
 
     public ResourceFinder(String path, ClassLoader classLoader) {
-        this(path, classLoader, null);
+        this(path, classLoader, nullArray());
     }
 
     public ResourceFinder(String path, ClassLoader classLoader, URL... urls) {
@@ -134,7 +125,7 @@ public class ResourceFinder {
         String fullUri = path + uri;
 
         Enumeration<URL> resources = getResources(fullUri);
-        List<URL> list = new ArrayList();
+        List<URL> list = new ArrayList<>();
         while (resources.hasMoreElements()) {
             URL url = resources.nextElement();
             list.add(url);

--- a/yawp-core/src/main/java/io/yawp/repository/AsyncRepository.java
+++ b/yawp-core/src/main/java/io/yawp/repository/AsyncRepository.java
@@ -12,10 +12,6 @@ public class AsyncRepository {
         return r.saveAsync(object);
     }
 
-    public <T> FutureObject<T> saveWithHooks(T object) {
-        return r.saveAsyncWithHooks(object);
-    }
-
     public <T> FutureObject<Void> destroy(IdRef<?> id) {
         return r.destroyAsync(id);
     }

--- a/yawp-core/src/main/java/io/yawp/repository/FutureObjectHook.java
+++ b/yawp-core/src/main/java/io/yawp/repository/FutureObjectHook.java
@@ -1,0 +1,5 @@
+package io.yawp.repository;
+
+public interface FutureObjectHook<T> {
+    void apply(Repository r, T object);
+}

--- a/yawp-core/src/main/java/io/yawp/repository/RepositoryApi.java
+++ b/yawp-core/src/main/java/io/yawp/repository/RepositoryApi.java
@@ -26,8 +26,6 @@ public interface RepositoryApi {
 
     AsyncRepository async();
 
-    <T> T saveWithHooks(T object);
-
     <T> T save(T object);
 
     <T> T fetch(IdRef<T> id);
@@ -35,8 +33,6 @@ public interface RepositoryApi {
     <T> FutureObject<T> fetchAsync(IdRef<T> id);
 
     Object action(IdRef<?> id, Class<?> clazz, ActionKey actionKey, String json, Map<String, String> params);
-
-    <T> QueryBuilder<T> queryWithHooks(Class<T> clazz);
 
     <T> QueryBuilder<T> query(Class<T> clazz);
 
@@ -63,7 +59,7 @@ public interface RepositoryApi {
 
     void commit();
 
-    boolean isTransationInProgress();
+    boolean isTransactionInProgress();
 
     TransactionDriver currentTransaction();
 

--- a/yawp-core/src/main/java/io/yawp/repository/Yawp.java
+++ b/yawp-core/src/main/java/io/yawp/repository/Yawp.java
@@ -77,7 +77,6 @@ public class Yawp extends ThreadLocal<Repository> implements RepositoryApi {
         safeLoadFeatures(configFile.getConfig().getPackages());
     }
 
-    @SuppressWarnings("deprecation")
     private static synchronized void safeLoadFeatures(String packagePrefix) {
         if (features != null) {
             return;
@@ -130,12 +129,6 @@ public class Yawp extends ThreadLocal<Repository> implements RepositoryApi {
     }
 
     @Override
-    public <T> T saveWithHooks(T object) {
-        init();
-        return get().saveWithHooks(object);
-    }
-
-    @Override
     public <T> T save(T object) {
         init();
         return get().save(object);
@@ -158,12 +151,6 @@ public class Yawp extends ThreadLocal<Repository> implements RepositoryApi {
     public Object action(IdRef<?> id, Class<?> clazz, ActionKey actionKey, String json, Map<String, String> params) {
         init();
         return get().action(id, clazz, actionKey, json, params);
-    }
-
-    @Override
-    public <T> QueryBuilder<T> queryWithHooks(Class<T> clazz) {
-        init();
-        return get().queryWithHooks(clazz);
     }
 
     @Override
@@ -239,9 +226,9 @@ public class Yawp extends ThreadLocal<Repository> implements RepositoryApi {
     }
 
     @Override
-    public boolean isTransationInProgress() {
+    public boolean isTransactionInProgress() {
         init();
-        return get().isTransationInProgress();
+        return get().isTransactionInProgress();
     }
 
     @Override

--- a/yawp-core/src/main/java/io/yawp/repository/actions/RepositoryActions.java
+++ b/yawp-core/src/main/java/io/yawp/repository/actions/RepositoryActions.java
@@ -28,7 +28,7 @@ public class RepositoryActions {
     }
 
     private static void atomicCommit(Repository r, boolean rollback) {
-        if (r.isTransationInProgress()) {
+        if (r.isTransactionInProgress()) {
             if (rollback) {
                 throw new RuntimeException(
                         "Running on devserver or unit tests? To test cross-group, default_high_rep_job_policy_unapplied_job_pct must be > 0");
@@ -39,7 +39,7 @@ public class RepositoryActions {
     }
 
     private static void atomicRollback(Repository r) {
-        if (r.isTransationInProgress()) {
+        if (r.isTransactionInProgress()) {
             r.rollback();
         }
     }

--- a/yawp-core/src/main/java/io/yawp/repository/features/Feature.java
+++ b/yawp-core/src/main/java/io/yawp/repository/features/Feature.java
@@ -27,10 +27,6 @@ public class Feature {
         return yawp.query(clazz);
     }
 
-    public <T> QueryBuilder<T> yawpWithHooks(Class<T> clazz) {
-        return yawp.queryWithHooks(clazz);
-    }
-
     public boolean isOnRequest() {
         return requestContext != null;
     }

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryFetchObject.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryFetchObject.java
@@ -1,0 +1,29 @@
+package io.yawp.repository.hooks;
+
+import io.yawp.repository.query.QueryBuilder;
+
+public class AfterQueryFetchObject<T> {
+    private QueryBuilder<T> query;
+    private T element;
+
+    public AfterQueryFetchObject(QueryBuilder<T> query, T element) {
+        this.query = query;
+        this.element = element;
+    }
+
+    public QueryBuilder<T> getQuery() {
+        return query;
+    }
+
+    public void setQuery(QueryBuilder<T> query) {
+        this.query = query;
+    }
+
+    public T getElement() {
+        return element;
+    }
+
+    public void setElement(T element) {
+        this.element = element;
+    }
+}

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryIdsObject.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryIdsObject.java
@@ -1,0 +1,32 @@
+package io.yawp.repository.hooks;
+
+import io.yawp.repository.IdRef;
+import io.yawp.repository.query.QueryBuilder;
+
+import java.util.List;
+
+public class AfterQueryIdsObject<T> {
+    private QueryBuilder<T> query;
+    private List<IdRef<T>> ids;
+
+    public AfterQueryIdsObject(QueryBuilder<T> query, List<IdRef<T>> ids) {
+        this.query = query;
+        this.ids = ids;
+    }
+
+    public QueryBuilder<T> getQuery() {
+        return query;
+    }
+
+    public void setQuery(QueryBuilder<T> query) {
+        this.query = query;
+    }
+
+    public List<IdRef<T>> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<IdRef<T>> ids) {
+        this.ids = ids;
+    }
+}

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryListObject.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/AfterQueryListObject.java
@@ -1,0 +1,31 @@
+package io.yawp.repository.hooks;
+
+import io.yawp.repository.query.QueryBuilder;
+
+import java.util.List;
+
+public class AfterQueryListObject<T> {
+    private QueryBuilder<T> query;
+    private List<T> list;
+
+    public AfterQueryListObject(QueryBuilder<T> query, List<T> list) {
+        this.query = query;
+        this.list = list;
+    }
+
+    public QueryBuilder<T> getQuery() {
+        return query;
+    }
+
+    public void setQuery(QueryBuilder<T> query) {
+        this.query = query;
+    }
+
+    public List<T> getList() {
+        return list;
+    }
+
+    public void setList(List<T> list) {
+        this.list = list;
+    }
+}

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/Hook.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/Hook.java
@@ -54,6 +54,30 @@ public class Hook<T> extends Feature {
     }
 
     /**
+     * Override this method to be invoked right after a query is executed,
+     * if that query ends up with a executeQuery call.
+     * @param obj an object containing the query performed and the result.
+     */
+    public void afterQuery(AfterQueryListObject<T> obj) {
+    }
+
+    /**
+     * Override this method to be invoked right after a query is executed,
+     * if that query ends up with a fetch by id operation.
+     * @param obj an object containing the query performed and the result.
+     */
+    public void afterQuery(AfterQueryFetchObject<T> obj) {
+    }
+
+    /**
+     * Override this method to be invoked right after a query is executed,
+     * if that query ends up with an ids only call.
+     * @param obj an object containing the query performed and the result.
+     */
+    public void afterQuery(AfterQueryIdsObject<T> obj) {
+    }
+
+    /**
      * Override this method to be invoked right before the endpoint model
      * is destroyed.
      *

--- a/yawp-core/src/main/java/io/yawp/repository/hooks/RepositoryHooks.java
+++ b/yawp-core/src/main/java/io/yawp/repository/hooks/RepositoryHooks.java
@@ -7,6 +7,7 @@ import io.yawp.repository.query.QueryBuilder;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
 
 public class RepositoryHooks {
 
@@ -26,6 +27,21 @@ public class RepositoryHooks {
 
     public static <T> void beforeQuery(Repository r, QueryBuilder<T> q, Class<T> clazz) {
         invokeHooks(r, clazz, q, "beforeQuery");
+    }
+
+    public static <T> void afterQueryList(QueryBuilder<T> query, List<T> list) {
+        AfterQueryListObject<T> obj = new AfterQueryListObject<>(query, list);
+        invokeHooks(query.getRepository(), query.getModel().getClazz(), obj,"afterQuery");
+    }
+
+    public static <T> void afterQueryFetch(QueryBuilder<T> query, T element) {
+        AfterQueryFetchObject<T> obj = new AfterQueryFetchObject<>(query, element);
+        invokeHooks(query.getRepository(), query.getModel().getClazz(), obj,"afterQuery");
+    }
+
+    public static <T> void afterQueryIds(QueryBuilder<T> query, List<IdRef<T>> ids) {
+        AfterQueryIdsObject<T> obj = new AfterQueryIdsObject<>(query, ids);
+        invokeHooks(query.getRepository(), query.getModel().getClazz(), obj,"afterQuery");
     }
 
     public static void beforeDestroy(Repository r, IdRef<?> id) {
@@ -64,16 +80,13 @@ public class RepositoryHooks {
         }
     }
 
-    private static Method getMethod(Object hook, String methodName, Class<?> argumentClazz) {
-
+    private static Method getMethod(Object hook, String methodName, Class<?>... argumentClazzes) {
         try {
-            return hook.getClass().getMethod(methodName, argumentClazz);
+            return hook.getClass().getMethod(methodName, argumentClazzes);
         } catch (NoSuchMethodException e) {
             return null;
         } catch (SecurityException e) {
             throw new RuntimeException(e);
         }
-
     }
-
 }

--- a/yawp-core/src/main/java/io/yawp/servlet/EndpointRouter.java
+++ b/yawp-core/src/main/java/io/yawp/servlet/EndpointRouter.java
@@ -143,11 +143,7 @@ public class EndpointRouter {
     private ActionKey nestedCollectionCustomActionKey(String lastToken) {
         String[] tokens = lastToken.split("/");
 
-        ActionKey actionKey = new ActionKey(rightCustomActionVerb(), tokens[1], true);
-        if (features.hasCustomAction("/" + tokens[0], actionKey)) {
-            return actionKey;
-        }
-        return null;
+        return createActionKey(tokens);
     }
 
     private HttpVerb rightCustomActionVerb() {
@@ -161,6 +157,10 @@ public class EndpointRouter {
             return null;
         }
 
+        return createActionKey(tokens);
+    }
+
+    private ActionKey createActionKey(String[] tokens) {
         ActionKey actionKey = new ActionKey(rightCustomActionVerb(), tokens[1], true);
         if (features.hasCustomAction("/" + tokens[0], actionKey)) {
             return actionKey;
@@ -207,7 +207,7 @@ public class EndpointRouter {
         return customActionKey.getActionName();
     }
 
-    protected RestAction createRestAction(boolean enableShields, boolean enableHooks) {
+    protected RestAction createRestAction(boolean enableShields) {
         logger.finer("creating rest action, verb: " + verb + ", custom=" + customActionKey);
 
         try {
@@ -217,7 +217,6 @@ public class EndpointRouter {
 
             action.setRepository(r);
             action.setEnableShields(enableShields);
-            action.setEnableHooks(enableHooks);
             action.setEndpointClazz(endpointClazz);
             action.setId(id);
             action.setParams(params);
@@ -225,7 +224,7 @@ public class EndpointRouter {
             action.setRequestJson(requestJson);
             action.setObjects(objects);
 
-            action.defineTrasnformer();
+            action.defineTransformer();
             action.defineShield();
 
             return action;
@@ -247,8 +246,8 @@ public class EndpointRouter {
         return Collections.singletonList(JsonUtils.from(r, requestJson, endpointClazz));
     }
 
-    public HttpResponse executeRestAction(boolean enableShields, boolean enableHooks) {
-        return createRestAction(enableShields, enableHooks).execute();
+    public HttpResponse executeRestAction(boolean enableShields) {
+        return createRestAction(enableShields).execute();
     }
 
     public boolean isValid() {

--- a/yawp-core/src/main/java/io/yawp/servlet/EndpointServlet.java
+++ b/yawp-core/src/main/java/io/yawp/servlet/EndpointServlet.java
@@ -23,8 +23,6 @@ public class EndpointServlet extends HttpServlet {
 
     private boolean enableShields = true;
 
-    private boolean enableHooks = true;
-
     private CrossDomainManager crossDomainManager = new CrossDomainManager();
 
     public EndpointServlet() {
@@ -38,7 +36,6 @@ public class EndpointServlet extends HttpServlet {
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
         setWithShields(config.getInitParameter("enableShields"));
-        setWithHooks(config.getInitParameter("enableHooks"));
         initYawp(config.getInitParameter("packagePrefix"));
 
         crossDomainManager.init(config);
@@ -59,21 +56,8 @@ public class EndpointServlet extends HttpServlet {
         setWithShields(enableShields);
     }
 
-    private void setWithHooks(String enableHooksParameter) {
-        if (!enableHooks) {
-            return;
-        }
-
-        boolean enableHooks = enableHooksParameter == null || Boolean.valueOf(enableHooksParameter);
-        setWithHooks(enableHooks);
-    }
-
     protected void setWithShields(boolean enableShields) {
         this.enableShields = enableShields;
-    }
-
-    protected void setWithHooks(boolean enableHooks) {
-        this.enableHooks = enableHooks;
     }
 
     /**
@@ -121,7 +105,7 @@ public class EndpointServlet extends HttpServlet {
                 throw new HttpException(400, "Invalid route. Please check uri, json format, object ids and parent structure, etc.");
             }
 
-            return router.executeRestAction(enableShields, enableHooks);
+            return router.executeRestAction(enableShields);
 
         } finally {
             Yawp.dispose();

--- a/yawp-core/src/main/java/io/yawp/servlet/FixturesServlet.java
+++ b/yawp-core/src/main/java/io/yawp/servlet/FixturesServlet.java
@@ -19,7 +19,6 @@ public class FixturesServlet extends EndpointServlet {
 	public void init(ServletConfig config) throws ServletException {
 		super.init(config);
 		setWithShields(false);
-		setWithHooks(false);
 	}
 
 	@Override

--- a/yawp-core/src/main/java/io/yawp/servlet/rest/RestAction.java
+++ b/yawp-core/src/main/java/io/yawp/servlet/rest/RestAction.java
@@ -34,8 +34,6 @@ public abstract class RestAction {
 
     private boolean enableShields;
 
-    protected boolean enableHooks;
-
     protected Class<?> endpointClazz;
 
     protected IdRef<?> id;
@@ -66,10 +64,6 @@ public abstract class RestAction {
 
     public void setEnableShields(boolean enableShields) {
         this.enableShields = enableShields;
-    }
-
-    public void setEnableHooks(boolean enableHooks) {
-        this.enableHooks = enableHooks;
     }
 
     public void setEndpointClazz(Class<?> clazz) {
@@ -122,7 +116,7 @@ public abstract class RestAction {
         Object object = action();
 
         logger.finer("creating response object");
-        if (HttpResponse.class.isInstance(object)) {
+        if (object instanceof HttpResponse) {
             return (HttpResponse) object;
         }
 
@@ -130,36 +124,22 @@ public abstract class RestAction {
     }
 
     private void executeShield() {
-        if (enableHooks) {
-            beforeShieldHooks();
-        }
-
         if (enableShields && hasShield()) {
+            beforeShieldHooks();
             shield();
         }
     }
 
     protected QueryBuilder<?> query() {
-        if (enableHooks) {
-            return r.queryWithHooks(endpointClazz);
-        }
         return r.query(endpointClazz);
     }
 
-    protected void save(Object object) {
-        if (enableHooks) {
-            r.saveWithHooks(object);
-        } else {
-            r.save(object);
-        }
+    protected <T> T save(T object) {
+        return r.save(object);
     }
 
-    protected FutureObject<Object> saveAsync(Object object) {
-        if (enableHooks) {
-            return r.async().saveWithHooks(object);
-        } else {
-            return r.async().save(object);
-        }
+    protected <T> FutureObject<T> saveAsync(T object) {
+        return r.async().save(object);
     }
 
     protected Object transform(Object object) {
@@ -215,7 +195,7 @@ public abstract class RestAction {
         return transformerName != null;
     }
 
-    public void defineTrasnformer() {
+    public void defineTransformer() {
         if (params.containsKey(TRANSFORMER)) {
             transformerName = params.get(TRANSFORMER);
             return;

--- a/yawp-core/src/test/java/io/yawp/driver/mock/MockPersistenceDriver.java
+++ b/yawp-core/src/test/java/io/yawp/driver/mock/MockPersistenceDriver.java
@@ -44,7 +44,7 @@ public class MockPersistenceDriver implements PersistenceDriver {
         MockStore.put(objectHolder.getId(), object, tx());
 
         Future<?> futureId = ConcurrentUtils.constantFuture(objectHolder.getId());
-        return new FutureObject<T>(r, (Future<IdRef<?>>) futureId, (T) object);
+        return new FutureObject<T>(r, (Future<IdRef<T>>) futureId, (T) object);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class MockPersistenceDriver implements PersistenceDriver {
     public FutureObject<Void> destroyAsync(IdRef<?> id) {
         destroy(id);
         Future<Void> future = ConcurrentUtils.constantFuture(null);
-        return new FutureObject<Void>(r, future);
+        return new FutureObject<>(r, future);
     }
 
     private void setIdIfNecessary(ObjectHolder objectHolder) {

--- a/yawp-core/src/test/java/io/yawp/driver/mock/MockQueryDriver.java
+++ b/yawp-core/src/test/java/io/yawp/driver/mock/MockQueryDriver.java
@@ -52,7 +52,7 @@ public class MockQueryDriver implements QueryDriver {
     @Override
     public <T> FutureObject<T> fetchAsync(IdRef<T> id) {
         T object = fetch(id);
-        Future<?> futureObject = ConcurrentUtils.constantFuture(object);
+        Future<T> futureObject = ConcurrentUtils.constantFuture(object);
         return new FutureObject<T>(r, futureObject);
     }
 
@@ -110,10 +110,10 @@ public class MockQueryDriver implements QueryDriver {
     private <T> List<T> applyLimit(QueryBuilder<?> builder, List<T> objects) {
         if (builder.getLimit() != null) {
             int limit = builder.getLimit() > objects.size() ? objects.size() : builder.getLimit();
-            return (List<T>) objects.subList(0, limit);
+            return objects.subList(0, limit);
         }
 
-        return (List<T>) objects;
+        return objects;
     }
 
     private List<Object> queryWhere(QueryBuilder<?> builder) {

--- a/yawp-core/src/test/java/io/yawp/repository/AsyncRepositoryTest.java
+++ b/yawp-core/src/test/java/io/yawp/repository/AsyncRepositoryTest.java
@@ -35,7 +35,7 @@ public class AsyncRepositoryTest extends EndpointTestCase {
     public void testBeforeSaveHook() {
         HookedObject object = new HookedObject("before_save");
 
-        FutureObject<HookedObject> future = yawp.async().saveWithHooks(object);
+        FutureObject<HookedObject> future = yawp.async().save(object);
         assertEquals("xpto before save", object.getStringValue());
         assertEquals("xpto before save", future.get().getStringValue());
     }
@@ -44,7 +44,7 @@ public class AsyncRepositoryTest extends EndpointTestCase {
     public void testAfterSaveHook() {
         HookedObject object = new HookedObject("after_save");
 
-        FutureObject<HookedObject> future = yawp.async().saveWithHooks(object);
+        FutureObject<HookedObject> future = yawp.async().save(object);
         assertEquals("after_save", object.getStringValue());
         assertEquals("xpto after save", future.get().getStringValue());
     }

--- a/yawp-core/src/test/java/io/yawp/repository/hooks/basic/HookTest.java
+++ b/yawp-core/src/test/java/io/yawp/repository/hooks/basic/HookTest.java
@@ -17,7 +17,7 @@ public class HookTest extends EndpointTestCase {
     public void testBeforeSave() {
         HookedObject object = new HookedObject("before_save");
 
-        yawp.saveWithHooks(object);
+        yawp.save(object);
         assertEquals("xpto before save", object.getStringValue());
 
         HookedObject retrievedObject = object.getId().fetch();
@@ -27,19 +27,28 @@ public class HookTest extends EndpointTestCase {
     @Test
     public void testAfterSave() {
         HookedObject object = new HookedObject("after_save");
-        yawp.saveWithHooks(object);
+        yawp.save(object);
         assertEquals("xpto after save", object.getStringValue());
+    }
+
+    public static class LoggedUser {
+        public static String filter;
     }
 
     @Test
     public void testBeforeQuery() {
-        yawp.save(new HookedObject("xpto1"));
-        yawp.save(new HookedObject("xpto2"));
+        try {
+            LoggedUser.filter = "xpto1";
+            yawp.save(new HookedObject("xpto1"));
+            yawp.save(new HookedObject("xpto2"));
 
-        List<HookedObject> objects = yawpWithHooks(HookedObject.class).list();
+            List<HookedObject> objects = yawp(HookedObject.class).list();
 
-        assertEquals(1, objects.size());
-        assertEquals("xpto1", objects.get(0).getStringValue());
+            assertEquals(1, objects.size());
+            assertEquals("xpto1", objects.get(0).getStringValue());
+        } finally {
+            LoggedUser.filter = null;
+        }
     }
 
     @Test
@@ -65,6 +74,4 @@ public class HookTest extends EndpointTestCase {
                 .list();
         assertEquals(1, objects.size());
     }
-
-
 }

--- a/yawp-core/src/test/java/io/yawp/repository/hooks/basic/SpecifObjectHook.java
+++ b/yawp-core/src/test/java/io/yawp/repository/hooks/basic/SpecifObjectHook.java
@@ -26,7 +26,10 @@ public class SpecifObjectHook extends Hook<HookedObject> {
 
     @Override
     public void beforeQuery(QueryBuilder<HookedObject> q) {
-        q.where("stringValue", "=", "xpto1");
+        if (HookTest.LoggedUser.filter == null) {
+            return;
+        }
+        q.where("stringValue", "=", HookTest.LoggedUser.filter);
     }
 
     @Override

--- a/yawp-core/src/test/java/io/yawp/repository/hooks/hierarchy/AllObjectsHook.java
+++ b/yawp-core/src/test/java/io/yawp/repository/hooks/hierarchy/AllObjectsHook.java
@@ -15,7 +15,7 @@ public class AllObjectsHook extends AbstractHook<Object> {
     }
 
     private boolean isHookTest(Object object) {
-        if (!HookedObject.class.isInstance(object)) {
+        if (!(object instanceof HookedObject)) {
             return false;
         }
         HookedObject hooked = (HookedObject) object;

--- a/yawp-core/src/test/java/io/yawp/repository/query/DatastoreQueryTest.java
+++ b/yawp-core/src/test/java/io/yawp/repository/query/DatastoreQueryTest.java
@@ -582,8 +582,8 @@ public class DatastoreQueryTest extends EndpointTestCase {
         ObjectSubClass child = new ObjectSubClass("xpto");
         yawp.save(child);
 
-        ObjectSubClass retrievedObject = yawp(ObjectSubClass.class).where("name", "=", "xpto").only();
-        assertEquals("xpto", retrievedObject.getName());
+        ObjectSubClass retrievedObject = yawp(ObjectSubClass.class).where("name", "=", "xpto + superclass hook").only();
+        assertEquals("xpto + superclass hook", retrievedObject.getName());
     }
 
     @Test(expected = RuntimeException.class)

--- a/yawp-core/src/test/java/io/yawp/servlet/EndpointRouterTest.java
+++ b/yawp-core/src/test/java/io/yawp/servlet/EndpointRouterTest.java
@@ -72,7 +72,7 @@ public class EndpointRouterTest extends ServletTestCase {
 
         try {
             get("");
-            assertTrue(false);
+            fail();
         } catch (HttpException e) {
             Welcome welcome = from(e.getText(), Welcome.class);
 
@@ -82,7 +82,7 @@ public class EndpointRouterTest extends ServletTestCase {
         }
         try {
             get("/");
-            assertTrue(false);
+            fail();
         } catch (HttpException e) {
             Welcome welcome = from(e.getText(), Welcome.class);
 
@@ -199,7 +199,7 @@ public class EndpointRouterTest extends ServletTestCase {
                 .uri("/parents/1/touched").build();
 
         EndpointRouter router = EndpointRouter.parse(yawp, ctx);
-        RestAction restAction = router.createRestAction(true, true);
+        RestAction restAction = router.createRestAction(true);
 
         assertEquals("touched", router.getCustomActionName());
         assertEquals(RoutesRestAction.class, restAction.getClass());

--- a/yawp-core/src/test/webapp/WEB-INF/web.xml
+++ b/yawp-core/src/test/webapp/WEB-INF/web.xml
@@ -11,11 +11,6 @@
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
         </init-param>
-
-        <init-param>
-            <param-name>enableCrossDomain</param-name>
-            <param-value>true</param-value>
-        </init-param>
     </servlet>
     <servlet-mapping>
         <servlet-name>EndpointServlet</servlet-name>
@@ -29,11 +24,6 @@
         <init-param>
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
-        </init-param>
-
-        <init-param>
-            <param-name>enableHooks</param-name>
-            <param-value>false</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/PGPersistenceDriver.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/PGPersistenceDriver.java
@@ -86,7 +86,7 @@ public class PGPersistenceDriver implements PersistenceDriver {
     private <T> FutureObject<T> saveEntityAsync(ObjectHolder objectHolder, Entity entity) {
         Key key = datastore.put(entity);
         Future<?> futureId = ConcurrentUtils.constantFuture(IdRefToKey.toIdRef(r, key, objectHolder.getModel()));
-        return new FutureObject<>(r, (Future<IdRef<?>>) futureId, (T) objectHolder.getObject());
+        return new FutureObject<>(r, (Future<IdRef<T>>) futureId, (T) objectHolder.getObject());
     }
 
     public void toEntity(ObjectHolder objectHolder, Entity entity) {

--- a/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/PGQueryDriver.java
+++ b/yawp-postgresql/src/main/java/io/yawp/driver/postgresql/PGQueryDriver.java
@@ -79,7 +79,7 @@ public class PGQueryDriver implements QueryDriver {
     @Override
     public <T> FutureObject<T> fetchAsync(IdRef<T> id) {
         T object = fetch(id);
-        Future<?> futureObject = ConcurrentUtils.constantFuture(object);
+        Future<T> futureObject = ConcurrentUtils.constantFuture(object);
         return new FutureObject<>(r, futureObject);
     }
 

--- a/yawp-testing/yawp-testing-appengine/src/test/webapp/WEB-INF/web.xml
+++ b/yawp-testing/yawp-testing-appengine/src/test/webapp/WEB-INF/web.xml
@@ -11,11 +11,6 @@
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
         </init-param>
-
-        <init-param>
-            <param-name>enableCrossDomain</param-name>
-            <param-value>true</param-value>
-        </init-param>
     </servlet>
     <servlet-mapping>
         <servlet-name>EndpointServlet</servlet-name>
@@ -29,11 +24,6 @@
         <init-param>
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
-        </init-param>
-
-        <init-param>
-            <param-name>enableHooks</param-name>
-            <param-value>false</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>

--- a/yawp-testing/yawp-testing-postgresql/src/test/webapp/WEB-INF/web.xml
+++ b/yawp-testing/yawp-testing-postgresql/src/test/webapp/WEB-INF/web.xml
@@ -11,11 +11,6 @@
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
         </init-param>
-
-        <init-param>
-            <param-name>enableCrossDomain</param-name>
-            <param-value>true</param-value>
-        </init-param>
     </servlet>
     <servlet-mapping>
         <servlet-name>EndpointServlet</servlet-name>
@@ -29,11 +24,6 @@
         <init-param>
             <param-name>packagePrefix</param-name>
             <param-value>io.yawp</param-value>
-        </init-param>
-
-        <init-param>
-            <param-name>enableHooks</param-name>
-            <param-value>false</param-value>
         </init-param>
     </servlet>
     <servlet-mapping>


### PR DESCRIPTION
This changes a lot regarding hooks, namely:

 * Hooks are now mandatory, enableHooks no longer exists. Hooks now take a more low-level fundamental step that is always activated, because they are no longer to be used for API security and other high level functions. For that, one must use Shields. Shields protect the API, Hooks bind into the Datastore.
* More hooks options: hooks added for afterQuery.
* Few other breaking changes: since we are breaking the API, I took the opportunity to refactor some bits that were messy (typos, generics, etc).

It's a huge commit that introduces lots of breaking changes. Please review it carefully.