### PR TITLE
Small fix on toMap function

### DIFF
--- a/yawp-core/src/main/java/io/yawp/repository/query/QueryBuilder.java
+++ b/yawp-core/src/main/java/io/yawp/repository/query/QueryBuilder.java
@@ -442,6 +442,7 @@ public class QueryBuilder<T> {
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("clazz", clazz.getCanonicalName());
+        result.put("executedQueryType", executedQueryType);
         result.put("parentId", parentId == null ? null : parentId.toString());
         result.put("condition", condition == null ? null : condition.toMap());
         result.put("preOrders", preOrders);


### PR DESCRIPTION
The `executedQueryType` fields makes for intrinsically distinct queries. For a potential, say, cache implementation using the `toMap` map to distinguish different queries, not having this field there will cause it to confuse different queries and return incorrect cached results.